### PR TITLE
Provide the document with category objects

### DIFF
--- a/lib/AI/Categorizer/Collection/DBI.pm
+++ b/lib/AI/Categorizer/Collection/DBI.pm
@@ -61,7 +61,7 @@ sub next {
   
   return $self->create_delayed_object('document',
 				      name => $result[0],
-				      categories => [$result[1]],
+				      categories => [AI::Categorizer::Category->by_name(name => $result[1])],
 				      content => $result[2],
 				     );
 }


### PR DESCRIPTION
Assuming that people don't actually store AI::Categorizer::Category
objects in their database, this patch will make sure to turn category
strings into objects, before creating the document object.
