### PR TITLE
fix spelling error raised by lintian

### DIFF
--- a/lib/AI/Categorizer/FeatureSelector/ChiSquare.pm
+++ b/lib/AI/Categorizer/FeatureSelector/ChiSquare.pm
@@ -41,7 +41,7 @@ __END__
 =head1 SYNOPSIS
 
  # the recommended way to use this class is to let the KnowledgeSet
- # instanciate it
+ # instantiate it
 
  use AI::Categorizer::KnowledgeSetSMART;
  my $ksetCHI = new AI::Categorizer::KnowledgeSetSMART(


### PR DESCRIPTION
while packaging AI::Categorizer in Debian, lintian found a spelling error in a pod section. here is the fix